### PR TITLE
fix: No warn for token unused

### DIFF
--- a/src/Adaptify.Compiler.Core/Adaptor.fs
+++ b/src/Adaptify.Compiler.Core/Adaptor.fs
@@ -1624,6 +1624,7 @@ module TypeDefinition =
             yield "#nowarn \"49\" // upper case patterns"
             yield "#nowarn \"66\" // upcast is unncecessary"
             yield "#nowarn \"1337\" // internal types"
+            yield "#nowarn \"1182\" // value is unused"
 
 
             let groups = all |> List.groupBy (fun d -> d.scope)

--- a/src/Adaptify.Compiler.Core/Runner.fs
+++ b/src/Adaptify.Compiler.Core/Runner.fs
@@ -119,6 +119,7 @@ module Adaptify =
                     yield "#nowarn \"49\" // upper case patterns"
                     yield "#nowarn \"66\" // upcast is unncecessary"
                     yield "#nowarn \"1337\" // internal types"
+                    yield "#nowarn \"1182\" // value is unused"
                 ]
             let m = rx.Match code
             if m.Success then


### PR DESCRIPTION
Otherwise, for projects where FS1182 is an error, developers will get `x.g.fs(19,61): error FS1182: The value 'token' is unused`.