### PR TITLE
- added global.json to limit problems with .net 7

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.203",
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/Adaptify.Compiler.Core/Runner.fs
+++ b/src/Adaptify.Compiler.Core/Runner.fs
@@ -152,7 +152,7 @@ module Adaptify =
             let projDir = Path.GetDirectoryName projectFile
             let outputDirectory = 
                 let dir = Path.Combine(Path.GetTempPath(), hash)
-                File.ensureDirectory dir
+                Directory.ensure dir |> ignore
                 dir
 
             let relativePath (name : string) =
@@ -531,7 +531,7 @@ module Adaptify =
                                         log.info Range.range0 "[Adaptify]   gen  %s" (relativePath outputFile)
 
                                 | FSharpCheckFileAnswer.Aborted ->
-                                    log.error Range.range0 "587" "[Adaptify]   could not parse %s" (relativePath file)
+                                    log.error Range.range0 "587" "[Adaptify]   could not parse (aborted) %s" (relativePath file)
                                     newFiles.Add file
                                     ()
                             else

--- a/src/Adaptify.Compiler/Program.fs
+++ b/src/Adaptify.Compiler/Program.fs
@@ -63,7 +63,7 @@ module ProjectInfo =
         let t = readTag s
         if t = success.Tag then
             let p = readSuccess(s).[0] :?> LoadedProject
-            match ProjectLoader.getLoadedProjectInfo file [] p with
+            match ProjectLoader.getLoadedProjectInfo (Path.GetFullPath file) [] p with
             | Result.Ok info ->
                 let isNewStyle =
                     info.ProjectSdkInfo.TargetFrameworks |> List.exists (fun f -> f.StartsWith "netframework")  |> not

--- a/src/Examples/Library/Library.fsproj
+++ b/src/Examples/Library/Library.fsproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+	 <DisableImplicitFSharpCoreReference>True</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Examples/Library/Library.g.fs
+++ b/src/Examples/Library/Library.g.fs
@@ -1,8 +1,9 @@
-//2d7e92ed-6829-f51b-35b0-6be6fc02b564
-//796e1e7a-b7b1-bbad-f4c9-b20b72c08313
+//fb015bb5-3676-a6f4-9c25-fb466dd692cf
+//db0a7f9c-2dd7-16c1-cb23-c133af4768b4
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
+#nowarn "1182" // value is unused
 namespace rec LibraryModel
 
 open System
@@ -12,6 +13,7 @@ open LibraryModel
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 type AdaptiveThing(value : Thing) =
     let _name_ = FSharp.Data.Adaptive.cval(value.name)
+    let _guhtest_ = FSharp.Data.Adaptive.cval(value.guhtest)
     let mutable __value = value
     let __adaptive = FSharp.Data.Adaptive.AVal.custom((fun (token : FSharp.Data.Adaptive.AdaptiveToken) -> __value))
     static member Create(value : Thing) = AdaptiveThing(value)
@@ -21,12 +23,10 @@ type AdaptiveThing(value : Thing) =
             __value <- value
             __adaptive.MarkOutdated()
             _name_.Value <- value.name
+            _guhtest_.Value <- value.guhtest
     member __.Current = __adaptive
     member __.name = _name_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
-[<AutoOpen; System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
-module ThingLenses = 
-    type Thing with
-        static member name_ = ((fun (self : Thing) -> self.name), (fun (value : Microsoft.FSharp.Core.string) (self : Thing) -> { self with name = value }))
+    member __.guhtest = _guhtest_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.int>
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 type AdaptiveMyUnionCase =
     abstract member Update : MyUnion -> AdaptiveMyUnionCase
@@ -145,11 +145,4 @@ type AdaptiveObject<'a, '_prima, '_aa>(value : Object<'a>, _primainit : 'a -> Sy
     member __.a = _a_ :> FSharp.Data.Adaptive.aval<Adaptify.FSharp.Core.AdaptiveResultCase<Object<'a>, AdaptiveObject<'a, '_prima, '_aa>, AdaptiveObject<'a, '_prima, '_aa>, Microsoft.FSharp.Core.string, Microsoft.FSharp.Core.string, FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>>>
     member __.b = _b_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.float>
     member __.map = _map_ :> FSharp.Data.Adaptive.amap<Microsoft.FSharp.Core.int, AdaptiveObject<'a, '_prima, '_aa>>
-[<AutoOpen; System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
-module ObjectLenses = 
-    type Object<'a> with
-        static member value_ = ((fun (self : Object<'a>) -> self.value), (fun (value : 'a) (self : Object<'a>) -> { self with value = value }))
-        static member a_ = ((fun (self : Object<'a>) -> self.a), (fun (value : Microsoft.FSharp.Core.Result<Object<'a>, Microsoft.FSharp.Core.string>) (self : Object<'a>) -> { self with a = value }))
-        static member b_ = ((fun (self : Object<'a>) -> self.b), (fun (value : Microsoft.FSharp.Core.float) (self : Object<'a>) -> { self with b = value }))
-        static member map_ = ((fun (self : Object<'a>) -> self.map), (fun (value : FSharp.Data.Adaptive.HashMap<Microsoft.FSharp.Core.int, Object<'a>>) (self : Object<'a>) -> { self with map = value }))
 

--- a/src/Examples/Library/Model2.g.fs
+++ b/src/Examples/Library/Model2.g.fs
@@ -1,8 +1,9 @@
-//05a89e3c-de71-db0d-8077-73738ec0cbc6
-//b9972a76-21af-0d46-d2df-57aeb54cbe44
+//01768e15-d2af-b3fe-e082-1b73c4955b4b
+//f3ff857d-791d-4e63-68e5-5fbc3a04ec33
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
+#nowarn "1182" // value is unused
 namespace rec LibraryModel2
 
 open System
@@ -30,9 +31,4 @@ type AdaptiveSoup(value : Soup) =
     member __.Current = __adaptive
     member __.important = _important_
     member __.things = _things_ :> FSharp.Data.Adaptive.amap<Microsoft.FSharp.Core.int, LibraryModel.AdaptiveThing>
-[<AutoOpen; System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
-module SoupLenses = 
-    type Soup with
-        static member important_ = ((fun (self : Soup) -> self.important), (fun (value : LibraryModel.Thing) (self : Soup) -> { self with important = value }))
-        static member things_ = ((fun (self : Soup) -> self.things), (fun (value : FSharp.Data.Adaptive.HashMap<Microsoft.FSharp.Core.int, LibraryModel.Thing>) (self : Soup) -> { self with things = value }))
 


### PR DESCRIPTION
- path used for resolving the project is now absolute (fix for https://github.com/krauthaufen/Adaptify/issues/32)
- for the outputdirectory, we used File.ensureDirectory instead of Directory.ensureDirectory - this seemed to make no problem as long as a file is generated since it used File.ensureDirectory for the output file
- fixed Library netstandard example


@krauthaufen most important change is here: https://github.com/krauthaufen/Adaptify/compare/bugs/ensureDirectoryAndAbsolutePaths?expand=1#diff-9fb1575b23ebba7cd9517e6998fa5d525e01f470b3374c9ce7435a3eb837966cR155
should be correct(er), right?

